### PR TITLE
compiler warning :  type defaults to ‘int’   -- can be avoided

### DIFF
--- a/OT7.c
+++ b/OT7.c
@@ -12084,7 +12084,7 @@ ParseFileNameParameter(
     u32 v;
     s8* S;
     u32 result;
-    static ParameterValueString[MAX_PARAMETER_VALUE_SIZE];
+    static u32 ParameterValueString[MAX_PARAMETER_VALUE_SIZE];
     
     // Set the default result code to be no error.
     result = RESULT_OK;

--- a/OT7.c
+++ b/OT7.c
@@ -11085,7 +11085,7 @@ ParseCommandLine(
     static u8 IsAppNamePrinted = 0;
     s8* S;
     u32 result;
-    static ParameterValueString[MAX_PARAMETER_VALUE_SIZE];
+    static u32 ParameterValueString[MAX_PARAMETER_VALUE_SIZE];
     
     // Set the default result code to be no error.
     result = RESULT_OK;


### PR DESCRIPTION
however, the binary passes the tests either way.

But adding "u32" may still be appropriate. thanks. 1-file-projects are just lovely, like ot7 and torIRC.
